### PR TITLE
AnsiConsole color handling

### DIFF
--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                                         SetColor(ConsoleColor.Gray);
                                         break;
                                     case 39:
-                                        SetColor(OriginalForegroundColor);
+                                        Console.ForegroundColor = OriginalForegroundColor;
                                         break;
                                 }
                             }

--- a/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
@@ -38,8 +38,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
             Console.ForegroundColor = 
                 c < 0 ? color :                                   // unknown, just use it
-                _boldRecursion > 0 ? (ConsoleColor)(c & ~Light) : // ensure color is dark
-                (ConsoleColor)(c | Light);                        // ensure color is light
+                _boldRecursion > 0 ? (ConsoleColor)(c | Light) :  // ensure color is light
+                (ConsoleColor)(c & ~Light);                       // ensure color is dark
         }
     
         private void SetBold(bool bold)


### PR DESCRIPTION
PR #1660 has alredy been merged - but there are actually two `AnsiConsole` classes (one in namespace `Microsoft.DotNet.Cli.Build.Framework` and the other in namespace `Microsoft.DotNet.Cli.Utils`.
With this PR both classes handle the colors in the same way.